### PR TITLE
Fixed set_write_value call for Tango 9

### DIFF
--- a/specifics/XpadPixelDetector/XpadPixelDetector.cpp
+++ b/specifics/XpadPixelDetector/XpadPixelDetector.cpp
@@ -227,7 +227,8 @@ void XpadPixelDetector::init_device()
 		string acqtype_mem_value = acqtype_attr.get_mem_value();
 		if (acqtype_mem_value == "Not used yet")
 		{
-			acqtype_attr.set_write_value("SYNC");
+            std::string str = "SYNC";
+			acqtype_attr.set_write_value(str);
 			write_acquisitionType(acqtype_attr);
 		}
 


### PR DESCRIPTION
Fixed XpadPixelDetector for Tango9

Was not compiling on linux32 due to wrong call of set_write_value