### PR TITLE
[ICATHALES-303] Fix write attributes at device init

### DIFF
--- a/specifics/Dhyana/Dhyana.xmi
+++ b/specifics/Dhyana/Dhyana.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
   <classes name="Dhyana" pogoRevision="9.6">
-    <description description="Interface the camera Dhyana using  the TUCAM Library" title="Device specific for Dhyana detector" sourcePath="/home/informatique/ica/hir/DeviceSources/Lima/applications/tango/cpp/specifics/Dhyana" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+    <description description="Interface the camera Dhyana using  the TUCAM Library" title="Device specific for Dhyana detector" sourcePath="/home/informatique/ica/bahji/Repositories_Dev/Lima/applications/tango/cpp/specifics/Dhyana" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_4Impl" sourcePath=""/>
       <identification contact="at synchrotron-soleil.fr - arafat.noureddine" author="arafat.noureddine" emailDomain="synchrotron-soleil.fr" classFamily="Acquisition" siteSpecific="" platform="Windows" bus="USB" manufacturer="" reference=""/>
     </description>
@@ -61,10 +61,11 @@
       <readExcludedStates>FAULT</readExcludedStates>
       <readExcludedStates>INIT</readExcludedStates>
     </attributes>
-    <attributes name="temperatureTarget" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="0" maxY="0" memorized="true">
+    <attributes name="temperatureTarget" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="0" maxY="0" allocReadMember="false" isDynamic="false">
       <dataType xsi:type="pogoDsl:DoubleType"/>
       <changeEvent fire="false" libCheckCriteria="false"/>
       <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <properties description="Set the Temperature target of the detector (in Celsius)" label="" unit="Celsius" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
       <readExcludedStates>FAULT</readExcludedStates>
@@ -73,24 +74,26 @@
       <writeExcludedStates>INIT</writeExcludedStates>
       <writeExcludedStates>RUNNING</writeExcludedStates>
     </attributes>
-    <attributes name="fanSpeed" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="0" maxY="0" memorized="true">
+    <attributes name="fanSpeed" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="0" maxY="0" allocReadMember="false" isDynamic="false">
       <dataType xsi:type="pogoDsl:UShortType"/>
       <changeEvent fire="false" libCheckCriteria="false"/>
       <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
-      <properties description="Define the fan speed of the detector [0..5]" label="" unit=" " standardUnit=" " displayUnit=" " format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
+      <properties description="Define the fan speed of the detector [0..5]" label="" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
       <readExcludedStates>FAULT</readExcludedStates>
       <readExcludedStates>INIT</readExcludedStates>
       <writeExcludedStates>FAULT</writeExcludedStates>
       <writeExcludedStates>INIT</writeExcludedStates>
       <writeExcludedStates>RUNNING</writeExcludedStates>
     </attributes>
-    <attributes name="globalGain" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="0" maxY="0" memorized="true">
+    <attributes name="globalGain" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="0" maxY="0" allocReadMember="false" isDynamic="false">
       <dataType xsi:type="pogoDsl:StringType"/>
       <changeEvent fire="false" libCheckCriteria="false"/>
       <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
-      <properties description="Define the gain of the detector [LOW, HIGH, HDR]" label="" unit=" " standardUnit=" " displayUnit=" " format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
+      <properties description="Define the gain of the detector [LOW, HIGH, HDR]" label="" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
       <readExcludedStates>FAULT</readExcludedStates>
       <readExcludedStates>INIT</readExcludedStates>
       <writeExcludedStates>FAULT</writeExcludedStates>
@@ -274,6 +277,6 @@
     <states name="STANDBY" description="">
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
+    <preferences docHome="../doc/doc_html" makefileHome="$(TANGO_HOME)"/>
   </classes>
 </pogoDsl:PogoSystem>

--- a/specifics/Dhyana/Dhyana.xmi
+++ b/specifics/Dhyana/Dhyana.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
   <classes name="Dhyana" pogoRevision="9.6">
-    <description description="Interface the camera Dhyana using  the TUCAM Library" title="Device specific for Dhyana detector" sourcePath="/home/informatique/ica/bahji/Repositories_Dev/Lima/applications/tango/cpp/specifics/Dhyana" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+    <description description="Interface the camera Dhyana using  the TUCAM Library" title="Device specific for Dhyana detector" sourcePath="/home/informatique/ica/hir/DeviceSources/Lima/applications/tango/cpp/specifics/Dhyana" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_4Impl" sourcePath=""/>
       <identification contact="at synchrotron-soleil.fr - arafat.noureddine" author="arafat.noureddine" emailDomain="synchrotron-soleil.fr" classFamily="Acquisition" siteSpecific="" platform="Windows" bus="USB" manufacturer="" reference=""/>
     </description>
@@ -277,6 +277,6 @@
     <states name="STANDBY" description="">
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </states>
-    <preferences docHome="../doc/doc_html" makefileHome="$(TANGO_HOME)"/>
+    <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
   </classes>
 </pogoDsl:PogoSystem>

--- a/specifics/Dhyana/DhyanaClass.cpp
+++ b/specifics/Dhyana/DhyanaClass.cpp
@@ -492,8 +492,7 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	temperaturetarget->set_default_properties(temperaturetarget_prop);
 	//	Not Polled
 	temperaturetarget->set_disp_level(Tango::OPERATOR);
-	temperaturetarget->set_memorized();
-	temperaturetarget->set_memorized_init(false);
+	//	Not Memorized
 	att_list.push_back(temperaturetarget);
 
 	//	Attribute : fanSpeed
@@ -501,9 +500,9 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	Tango::UserDefaultAttrProp	fanspeed_prop;
 	fanspeed_prop.set_description("Define the fan speed of the detector [0..5]");
 	//	label	not set for fanSpeed
-	fanspeed_prop.set_unit(" ");
-	fanspeed_prop.set_standard_unit(" ");
-	fanspeed_prop.set_display_unit(" ");
+	//	unit	not set for fanSpeed
+	//	standard_unit	not set for fanSpeed
+	//	display_unit	not set for fanSpeed
 	//	format	not set for fanSpeed
 	//	max_value	not set for fanSpeed
 	//	min_value	not set for fanSpeed
@@ -517,8 +516,7 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	fanspeed->set_default_properties(fanspeed_prop);
 	//	Not Polled
 	fanspeed->set_disp_level(Tango::OPERATOR);
-	fanspeed->set_memorized();
-	fanspeed->set_memorized_init(false);
+	//	Not Memorized
 	att_list.push_back(fanspeed);
 
 	//	Attribute : globalGain
@@ -526,9 +524,9 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	Tango::UserDefaultAttrProp	globalgain_prop;
 	globalgain_prop.set_description("Define the gain of the detector [LOW, HIGH, HDR]");
 	//	label	not set for globalGain
-	globalgain_prop.set_unit(" ");
-	globalgain_prop.set_standard_unit(" ");
-	globalgain_prop.set_display_unit(" ");
+	//	unit	not set for globalGain
+	//	standard_unit	not set for globalGain
+	//	display_unit	not set for globalGain
 	//	format	not set for globalGain
 	//	max_value	not set for globalGain
 	//	min_value	not set for globalGain
@@ -542,8 +540,7 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	globalgain->set_default_properties(globalgain_prop);
 	//	Not Polled
 	globalgain->set_disp_level(Tango::OPERATOR);
-	globalgain->set_memorized();
-	globalgain->set_memorized_init(false);
+	//	Not Memorized
 	att_list.push_back(globalgain);
 
 	//	Attribute : fps

--- a/specifics/Dhyana/DhyanaClass.cpp
+++ b/specifics/Dhyana/DhyanaClass.cpp
@@ -500,9 +500,9 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	Tango::UserDefaultAttrProp	fanspeed_prop;
 	fanspeed_prop.set_description("Define the fan speed of the detector [0..5]");
 	//	label	not set for fanSpeed
-	//	unit	not set for fanSpeed
-	//	standard_unit	not set for fanSpeed
-	//	display_unit	not set for fanSpeed
+	fanspeed_prop.set_unit(" ");
+	fanspeed_prop.set_standard_unit(" ");
+	fanspeed_prop.set_display_unit(" ");
 	//	format	not set for fanSpeed
 	//	max_value	not set for fanSpeed
 	//	min_value	not set for fanSpeed
@@ -524,9 +524,9 @@ void DhyanaClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	Tango::UserDefaultAttrProp	globalgain_prop;
 	globalgain_prop.set_description("Define the gain of the detector [LOW, HIGH, HDR]");
 	//	label	not set for globalGain
-	//	unit	not set for globalGain
-	//	standard_unit	not set for globalGain
-	//	display_unit	not set for globalGain
+	globalgain_prop.set_unit(" ");
+	globalgain_prop.set_standard_unit(" ");
+	globalgain_prop.set_display_unit(" ");
 	//	format	not set for globalGain
 	//	max_value	not set for globalGain
 	//	min_value	not set for globalGain


### PR DESCRIPTION
Remove memorized option in Pogo for the attributes: temperatureTarget  / fanSpeed / globalGain so the write attributes is handled only by code