### PR TITLE
see #ICTHALES-590 : Evolution Lima DS PCO Dimax

### DIFF
--- a/specifics/Pco/Pco.h
+++ b/specifics/Pco/Pco.h
@@ -118,6 +118,10 @@ namespace Pco_ns
 		Tango::DevString	*attr_cameraModel_read;
 		Tango::DevFloat	*attr_sensorTemperature_read;
 		Tango::DevString	*attr_dllVersion_read;
+		Tango::DevString	*attr_storageMode_read;
+		Tango::DevString	attr_storageMode_write;
+		Tango::DevBoolean	*attr_ringBuffer_read;
+		Tango::DevBoolean	attr_ringBuffer_write;
 //@}
 
         /**
@@ -226,6 +230,22 @@ namespace Pco_ns
  */
 	virtual void read_dllVersion(Tango::Attribute &attr);
 /**
+ *	Extract real attribute values for storageMode acquisition result.
+ */
+	virtual void read_storageMode(Tango::Attribute &attr);
+/**
+ *	Write storageMode attribute values to hardware.
+ */
+	virtual void write_storageMode(Tango::WAttribute &attr);
+/**
+ *	Extract real attribute values for ringBuffer acquisition result.
+ */
+	virtual void read_ringBuffer(Tango::Attribute &attr);
+/**
+ *	Write ringBuffer attribute values to hardware.
+ */
+	virtual void write_ringBuffer(Tango::WAttribute &attr);
+/**
  *	Read/Write allowed for pixelRate attribute.
  */
 	virtual bool is_pixelRate_allowed(Tango::AttReqType type);
@@ -241,6 +261,14 @@ namespace Pco_ns
  *	Read/Write allowed for dllVersion attribute.
  */
 	virtual bool is_dllVersion_allowed(Tango::AttReqType type);
+/**
+ *	Read/Write allowed for storageMode attribute.
+ */
+	virtual bool is_storageMode_allowed(Tango::AttReqType type);
+/**
+ *	Read/Write allowed for ringBuffer attribute.
+ */
+	virtual bool is_ringBuffer_allowed(Tango::AttReqType type);
 /**
  *	Execution allowed for Talk command.
  */

--- a/specifics/Pco/PcoClass.cpp
+++ b/specifics/Pco/PcoClass.cpp
@@ -339,6 +339,23 @@ void PcoClass::attribute_factory(vector<Tango::Attr *> &att_list)
 	dll_version->set_disp_level(Tango::EXPERT);
 	att_list.push_back(dll_version);
 
+	//	Attribute : storageMode
+	storageModeAttrib	*storage_mode = new storageModeAttrib();
+	Tango::UserDefaultAttrProp	storage_mode_prop;
+	storage_mode_prop.set_label("Storage Mode");
+	storage_mode_prop.set_unit("");
+	storage_mode_prop.set_description("Set/Get the storage mode. Values :\n RECORDER\n FIFO\n");
+	storage_mode->set_default_properties(storage_mode_prop);
+	storage_mode->set_memorized();
+	storage_mode->set_memorized_init(false);
+	att_list.push_back(storage_mode);
+
+	//	Attribute : ringBuffer
+	ringBufferAttrib	*ring_buffer = new ringBufferAttrib();
+	ring_buffer->set_memorized();
+	ring_buffer->set_memorized_init(false);
+	att_list.push_back(ring_buffer);
+
 	//	End of Automatic code generation
 	//-------------------------------------------------------------
 }

--- a/specifics/Pco/PcoClass.h
+++ b/specifics/Pco/PcoClass.h
@@ -46,6 +46,34 @@ namespace Pco_ns
 {//=====================================
 //	Define classes for attributes
 //=====================================
+class ringBufferAttrib: public Tango::Attr
+{
+public:
+	ringBufferAttrib():Attr("ringBuffer", Tango::DEV_BOOLEAN, Tango::READ_WRITE) {};
+	~ringBufferAttrib() {};
+	
+	virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
+	{(static_cast<Pco *>(dev))->read_ringBuffer(att);}
+	virtual void write(Tango::DeviceImpl *dev,Tango::WAttribute &att)
+	{(static_cast<Pco *>(dev))->write_ringBuffer(att);}
+	virtual bool is_allowed(Tango::DeviceImpl *dev,Tango::AttReqType ty)
+	{return (static_cast<Pco *>(dev))->is_ringBuffer_allowed(ty);}
+};
+
+class storageModeAttrib: public Tango::Attr
+{
+public:
+	storageModeAttrib():Attr("storageMode", Tango::DEV_STRING, Tango::READ_WRITE) {};
+	~storageModeAttrib() {};
+	
+	virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
+	{(static_cast<Pco *>(dev))->read_storageMode(att);}
+	virtual void write(Tango::DeviceImpl *dev,Tango::WAttribute &att)
+	{(static_cast<Pco *>(dev))->write_storageMode(att);}
+	virtual bool is_allowed(Tango::DeviceImpl *dev,Tango::AttReqType ty)
+	{return (static_cast<Pco *>(dev))->is_storageMode_allowed(ty);}
+};
+
 class dllVersionAttrib: public Tango::Attr
 {
 public:

--- a/specifics/Pco/PcoStateMachine.cpp
+++ b/specifics/Pco/PcoStateMachine.cpp
@@ -141,6 +141,56 @@ bool Pco::is_sensorTemperature_allowed(Tango::AttReqType type)
 	}
 	return true;
 }
+//+----------------------------------------------------------------------------
+//
+// method : 		Pco::is_storageMode_allowed
+// 
+// description : 	Read/Write allowed for storageMode attribute.
+//
+//-----------------------------------------------------------------------------
+bool Pco::is_storageMode_allowed(Tango::AttReqType type)
+{
+	if (get_state() == Tango::INIT	||
+		get_state() == Tango::FAULT	||
+		get_state() == Tango::DISABLE	||
+		get_state() == Tango::RUNNING)
+	{
+		//	End of Generated Code
+        if (get_state() == Tango::RUNNING && type == Tango::READ_REQ)
+        {
+            return true;
+        }
+
+		//	Re-Start of Generated Code
+		return false;
+	}
+	return true;
+}
+//+----------------------------------------------------------------------------
+//
+// method : 		Pco::is_ringBuffer_allowed
+// 
+// description : 	Read/Write allowed for ringBuffer attribute.
+//
+//-----------------------------------------------------------------------------
+bool Pco::is_ringBuffer_allowed(Tango::AttReqType type)
+{
+	if (get_state() == Tango::INIT	||
+		get_state() == Tango::FAULT	||
+		get_state() == Tango::DISABLE	||
+		get_state() == Tango::RUNNING)
+	{
+		//	End of Generated Code
+        if (get_state() == Tango::RUNNING && type == Tango::READ_REQ)
+        {
+            return true;
+        }
+
+		//	Re-Start of Generated Code
+		return false;
+	}
+	return true;
+}
 
 //=================================================
 //		Commands Allowed Methods


### PR DESCRIPTION
Il y a quelques évolutions souhaitable dans le DS pour le PCO dimax, pour rajouter des fonctionnalités disponible dans le CamWare, et a priori disponible avec le DS utilisé a l'ESRF - Mario va pouvoir confirmer.

(1) Accès au mode "ring buffer" (acquisition en RAM en continue, arrêt avec un post-trigger). exemple d'usage:

on lance une acquisition , qui tourne "indéfiniment" , en enregistrant en RAM les images, qui sont écrasées au fur à mesure (ring buffer)
une fois que l’évènement de l’expérience est arrivé (eg une bille qui tombe): l'utilisateur arrête manuellement l'acquisition
on récupère les N dernières images qui normalement contiendront la bille tombée
pour cela il faut que les images soient remontées dans le device pour que l'utilisateur puisse voir en direct (cf mode live ci dessous)
(2) Visualiser les images en cours d'acquisition en direct, avant le lecteur complete du RAM.